### PR TITLE
Delete obsolete license.txt

### DIFF
--- a/license.txt
+++ b/license.txt
@@ -1,8 +1,0 @@
-The DITA Open Toolkit is licensed for use under the the Apache Software Foundation License v2.0.  
-If, at the time of use, the Project Management Committee has designated another 
-version of this license or another license as being applicable to the 
-DITA Open Toolkit, user may select to have its subsequent use of the 
-DITA Open Toolkit governed by such other designated license.  
-A copy of the Apache Software Foundation License 2.0 is available at 
-http://opensource.org/licenses/apache2.0.php
-This statement must be included in any copies of DITA Open Toolkit code.


### PR DESCRIPTION
A copy of this file was shipped for many releases in DITA-OT, up to release 2.2.

In 2.3 it was modified to remove language about future versions - we don't need to make statements or guesses about what might happen with future versions of DITA-OT, and no changes are currently expected.

In 2.4 the file was removed entirely from DITA-OT; we ship `LICENSE` (with a copy of Apache 2.0) so there is no reason to ship an additional `license.txt` that just says "we are licensed under apache 2.0". We should do the same here, for the same reason.

This is opened based on an issue originally raised in the DITA-OT repository here: https://github.com/dita-ot/dita-ot/issues/2813